### PR TITLE
Fix superscript markdown not capturing the actual value

### DIFF
--- a/apps/mobile/src/lib/markdown.ts
+++ b/apps/mobile/src/lib/markdown.ts
@@ -14,7 +14,7 @@ import { gfmTable } from 'micromark-extension-gfm-table'
 export function parse(markdown: string) {
   const value = markdown
     .replaceAll(/>!(.*?)!</g, ':spoiler[$1]')
-    .replaceAll(/\^\w+/g, ':super_script[$1]')
+    .replaceAll(/\^(\w+)/g, ':super_script[$1]')
     .replaceAll(/\^\((.*?)\)/g, ':super_script[$1]')
     .replaceAll(
       /(?<!\S)(?:\/?r\/(?!\/))([\w-]+)\b/g,


### PR DESCRIPTION
Superscript markdown was not being handled properly (the value wasn't actually captured in the regex, which means that the replacement was always "$1"). Fix to properly capture the value.

Using https://reddit.com/r/askscience/comments/1hv6cey/is_it_possible_to_contain_light_and_if_so_would/m5re4mc/ as an example:

Previously:
<img width="359" alt="image" src="https://github.com/user-attachments/assets/b7fe6e44-8c8a-40e2-b7ab-5fdc4de6c937" />

After fix:
<img width="357" alt="image" src="https://github.com/user-attachments/assets/228bcf4b-8409-43b6-a9ea-12d1c90f010a" />
