### PR TITLE
update icons to work with iOS 16

### DIFF
--- a/apps/mobile/src/app/(drawer)/(tabs)/(home,search,profile,notifications,settings)/profile.tsx
+++ b/apps/mobile/src/app/(drawer)/(tabs)/(home,search,profile,notifications,settings)/profile.tsx
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native'
 import { useRouter } from 'expo-router'
 import { type SFSymbol } from 'expo-symbols'
 import { ScrollView } from 'react-native'
@@ -85,12 +86,12 @@ export default function Screen() {
 }
 
 const icons: Record<UserFeedType, SFSymbol> = {
-  comments: 'bubble',
-  downvoted: 'arrowshape.down',
+  comments: (Number(Platform.Version) >= 17) ? 'bubble' : 'bubble.right',
+  downvoted: (Number(Platform.Version) >= 17) ? 'arrowshape.down' : 'arrow.down',
   hidden: 'eye.slash',
   saved: 'bookmark',
   submitted: 'paperplane',
-  upvoted: 'arrowshape.up',
+  upvoted: (Number(Platform.Version) >= 17) ? 'arrowshape.up' : 'arrow.up',
 }
 
 const colors: Record<UserFeedType, ColorToken> = {

--- a/apps/mobile/src/app/(drawer)/(tabs)/(home,search,profile,notifications,settings)/settings/preferences.tsx
+++ b/apps/mobile/src/app/(drawer)/(tabs)/(home,search,profile,notifications,settings)/settings/preferences.tsx
@@ -1,4 +1,4 @@
-import { ScrollView } from 'react-native'
+import { Platform, ScrollView } from 'react-native'
 import { useFormatter, useTranslations } from 'use-intl'
 
 import { FloatingButtonSide } from '~/components/common/floating-button'
@@ -232,7 +232,7 @@ export default function Screen() {
         />
 
         <Menu.Switch
-          icon={<Icon name="arrowshape.up" />}
+          icon={<Icon name= {(Number(Platform.Version) >= 17) ? 'arrowshape.up' : 'arrow.up'} />}
           label={t('posts.upvoteOnSave')}
           onChange={(next) => {
             update({
@@ -352,7 +352,7 @@ export default function Screen() {
         <Menu.Label>{t('history.title')}</Menu.Label>
 
         <Menu.Switch
-          icon={<Icon name="arrowshape.up" />}
+          icon={<Icon name= {(Number(Platform.Version) >= 17) ? 'arrowshape.up' : 'arrow.up'} />}
           label={t('history.seenOnVote')}
           onChange={(next) => {
             update({

--- a/apps/mobile/src/components/comments/menu.tsx
+++ b/apps/mobile/src/components/comments/menu.tsx
@@ -4,6 +4,7 @@ import { Alert, Share } from 'react-native'
 import { toast } from 'sonner-native'
 import { useTranslations } from 'use-intl'
 
+import { icons } from '~/components/common/gestures/actions'
 import { useCopy } from '~/hooks/copy'
 import { useLink } from '~/hooks/link'
 import { useHide } from '~/hooks/moderation/hide'
@@ -51,7 +52,9 @@ export function CommentMenu({ children, comment }: Props) {
       <Link.Menu>
         <Link.Menu displayAsPalette displayInline>
           <Link.MenuAction
-            icon={comment.liked ? 'arrowshape.up.fill' : 'arrowshape.up'}
+            icon={
+              comment.liked ? `${icons.upvote}.fill` :  icons.upvote
+            }
             onPress={() => {
               vote({
                 commentId: comment.id,
@@ -64,9 +67,7 @@ export function CommentMenu({ children, comment }: Props) {
 
           <Link.MenuAction
             icon={
-              comment.liked === false
-                ? 'arrowshape.down.fill'
-                : 'arrowshape.down'
+              comment.liked === false ? `${icons.downvote}.fill` :  icons.downvote
             }
             onPress={() => {
               vote({

--- a/apps/mobile/src/components/comments/meta.tsx
+++ b/apps/mobile/src/components/comments/meta.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'expo-router'
 import { StyleSheet } from 'react-native-unistyles'
 import { useFormatter, useTranslations } from 'use-intl'
 
+import { icons } from '~/components/common/gestures/actions'
 import { useCommentVote } from '~/hooks/mutations/comments/vote'
 import { removePrefix } from '~/lib/reddit'
 import { space } from '~/styles/tokens'
@@ -127,7 +128,9 @@ export function CommentMeta({ collapsed, comment, flair, top }: Props) {
         <FooterButton
           color={comment.liked === true ? 'orange' : undefined}
           compact
-          icon={comment.liked === true ? 'arrowshape.up.fill' : 'arrowshape.up'}
+          icon={
+            comment.liked === true ? `${icons.upvote}.fill` :  icons.upvote
+          }          
           label={a11y(comment.liked ? 'removeUpvote' : 'upvote')}
           onPress={() => {
             vote({
@@ -148,7 +151,7 @@ export function CommentMeta({ collapsed, comment, flair, top }: Props) {
           color={comment.liked === false ? 'violet' : undefined}
           compact
           icon={
-            comment.liked === false ? 'arrowshape.down.fill' : 'arrowshape.down'
+            comment.liked === false ? `${icons.downvote}.fill` :  icons.downvote
           }
           label={a11y(comment.liked === false ? 'removeDownvote' : 'downvote')}
           onPress={() => {

--- a/apps/mobile/src/components/common/gestures/actions.tsx
+++ b/apps/mobile/src/components/common/gestures/actions.tsx
@@ -1,6 +1,6 @@
 import { type SFSymbol } from 'expo-symbols'
 import { useState } from 'react'
-import { type StyleProp, type ViewStyle } from 'react-native'
+import { Platform, type StyleProp, type ViewStyle } from 'react-native'
 import Animated, {
   runOnJS,
   type SharedValue,
@@ -93,12 +93,12 @@ export const colors: Record<GestureAction, ColorToken> = {
 }
 
 export const icons = {
-  downvote: 'arrowshape.down',
+  downvote: (Number(Platform.Version) >= 17) ? 'arrowshape.down' : 'arrow.down.circle',
   hide: 'eye.slash',
   reply: 'arrowshape.turn.up.backward',
   save: 'bookmark',
   share: 'square.and.arrow.up',
-  upvote: 'arrowshape.up',
+  upvote: (Number(Platform.Version) >= 17) ? 'arrowshape.up' : 'arrow.up.circle',
 } as const satisfies Record<GestureAction, SFSymbol>
 
 export function getIcon(action: GestureAction, data: GestureData): SFSymbol {

--- a/apps/mobile/src/components/inbox/notification.tsx
+++ b/apps/mobile/src/components/inbox/notification.tsx
@@ -15,6 +15,7 @@ import { Icon } from '../common/icon'
 import { Pressable } from '../common/pressable'
 import { Text } from '../common/text'
 import { View } from '../common/view'
+import { Platform } from 'react-native'
 
 type Props = {
   notification: InboxNotification
@@ -121,7 +122,7 @@ const styles = StyleSheet.create((theme) => ({
 }))
 
 const icons = {
-  comment_reply: 'bubble',
+  comment_reply: (Number(Platform.Version) >= 17) ? 'bubble' : 'bubble.right',
   post_reply: 'arrowshape.turn.up.backward',
   username_mention: 'person',
 } as const satisfies Record<NotificationType, SFSymbol>

--- a/apps/mobile/src/components/posts/footer/crosspost.tsx
+++ b/apps/mobile/src/components/posts/footer/crosspost.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'expo-router'
+import { Platform } from 'react-native'
 import { StyleSheet } from 'react-native-unistyles'
 import { useFormatter, useTranslations } from 'use-intl'
 
@@ -21,14 +22,14 @@ export function CrossPostFooter({ post }: Props) {
 
   const footer = [
     {
-      icon: 'arrowshape.up',
+      icon: (Number(Platform.Version) >= 17) ? 'arrowshape.up' : 'arrow.up',
       key: 'votes',
       label: f.number(post.votes, {
         notation: 'compact',
       }),
     },
     {
-      icon: 'bubble',
+      icon: (Number(Platform.Version) >= 17) ? 'bubble' : 'bubble.right',
       key: 'comments',
       label: f.number(post.comments, {
         notation: 'compact',

--- a/apps/mobile/src/components/posts/footer/index.tsx
+++ b/apps/mobile/src/components/posts/footer/index.tsx
@@ -6,6 +6,7 @@ import { usePostVote } from '~/hooks/mutations/posts/vote'
 import { usePreferences } from '~/stores/preferences'
 import { type Post } from '~/types/post'
 
+import { icons } from '~/components/common/gestures/actions'
 import { FooterButton } from './button'
 import { PostCommunity } from './community'
 import { PostMeta } from './meta'
@@ -44,7 +45,7 @@ export function PostFooter({ community = true, post, style }: Props) {
           <FooterButton
             color={post.liked === true ? 'orange' : undefined}
             fill={post.liked === true}
-            icon="arrowshape.up.fill"
+            icon={`${icons.upvote}.fill`}
             label={a11y(post.liked ? 'removeUpvote' : 'upvote')}
             onPress={() => {
               vote({
@@ -57,7 +58,7 @@ export function PostFooter({ community = true, post, style }: Props) {
           <FooterButton
             color={post.liked === false ? 'violet' : undefined}
             fill={post.liked === false}
-            icon="arrowshape.down.fill"
+            icon={`${icons.downvote}.fill`}
             label={a11y(post.liked === false ? 'removeDownvote' : 'downvote')}
             onPress={() => {
               vote({

--- a/apps/mobile/src/components/posts/footer/meta.tsx
+++ b/apps/mobile/src/components/posts/footer/meta.tsx
@@ -1,5 +1,7 @@
 import { useFormatter } from 'use-intl'
+import { Platform } from 'react-native'
 
+import { icons } from '~/components/common/gestures/actions'
 import { Icon } from '~/components/common/icon'
 import { Text } from '~/components/common/text'
 import { TimeAgo } from '~/components/common/time'
@@ -20,7 +22,7 @@ export function PostMeta({ post }: Props) {
         : post.liked === false
           ? 'violet'
           : undefined,
-      icon: post.liked === false ? 'arrowshape.down' : 'arrowshape.up',
+      icon: post.liked === false ? icons.downvote : icons.upvote,
       key: 'votes',
       label: f.number(post.votes, {
         notation: 'compact',
@@ -35,7 +37,7 @@ export function PostMeta({ post }: Props) {
       }),
     },
     {
-      icon: 'bubble',
+      icon: (Number(Platform.Version) >= 17) ? 'bubble' : 'bubble.right',
       key: 'comments',
       label: f.number(post.comments, {
         notation: 'compact',

--- a/apps/mobile/src/components/posts/menu.tsx
+++ b/apps/mobile/src/components/posts/menu.tsx
@@ -4,6 +4,7 @@ import { Alert, Share } from 'react-native'
 import { toast } from 'sonner-native'
 import { useTranslations } from 'use-intl'
 
+import { icons } from '~/components/common/gestures/actions'
 import { useCopy } from '~/hooks/copy'
 import { useDownloadImages } from '~/hooks/image'
 import { useLink } from '~/hooks/link'
@@ -57,7 +58,9 @@ export function PostMenu({ children, post }: Props) {
       <Link.Menu>
         <Link.Menu displayAsPalette displayInline>
           <Link.MenuAction
-            icon={post.liked ? 'arrowshape.up.fill' : 'arrowshape.up'}
+            icon={
+              post.liked ? `${icons.upvote}.fill` :  icons.upvote
+            }
             onPress={() => {
               vote({
                 direction: post.liked ? 0 : 1,
@@ -69,7 +72,7 @@ export function PostMenu({ children, post }: Props) {
 
           <Link.MenuAction
             icon={
-              post.liked === false ? 'arrowshape.down.fill' : 'arrowshape.down'
+              post.liked === false ? `${icons.downvote}.fill` :  icons.downvote
             }
             onPress={() => {
               vote({

--- a/apps/mobile/src/lib/sort.ts
+++ b/apps/mobile/src/lib/sort.ts
@@ -1,11 +1,12 @@
 import { type SFSymbol } from 'expo-symbols'
+import { Platform } from 'react-native'
 
 import { type ColorToken } from '~/styles/tokens'
 import { type FeedType, type PostSort, type TopInterval } from '~/types/sort'
 
 export const SortIcons: Record<PostSort, SFSymbol> = {
   best: 'medal',
-  comments: 'bubble',
+  comments: (Number(Platform.Version) >= 17) ? 'bubble' : 'bubble.right',
   confidence: 'medal',
   controversial: 'star',
   hot: 'flame',


### PR DESCRIPTION
Hey, I have an older test device running iOS 16 and noticed in one of the recent builds, you swapped over to SF Symbols 🎉. However, several symbols, such as `bubble`, and the upvote / downvote arrows sadly require iOS 17+.
<img width="1552" height="892" alt="Screenshot 2025-09-23 at 11 18 03 pm" src="https://github.com/user-attachments/assets/7afebb36-94ba-488b-ac36-549575f2b8bf" />
<img width="1552" height="892" alt="Screenshot 2025-09-23 at 11 18 45 pm" src="https://github.com/user-attachments/assets/9057c4b6-3eda-4c01-8358-2032b9c12b07" />
As the app still targets and functions beautifully on iOS 16, I've added fallbacks to the problematic icons. When a SF Icon is missing, they simply just don't render. Hence below is an example of the icons missing on iOS 16.7 (the issue I'm trying to fix)
![IMG_CA1176F7F3A3-1](https://github.com/user-attachments/assets/fbc7a677-d4e5-4237-8343-8fce096294d8)
I believe the fallbacks added in this PR should render as expected on these older devices, and still match the UI / theming you're going for, or at least as close as possible.
Unfortunately I'm not familiar with Expo / EAS so I'm struggling on getting a working / running build on my device.
But hopefully this PR is a step in the right direction. Would be more than happy for you to tweak / edit this to perfection. Just wanted to help make maintaining the code on older iOS much easier.

Really appreciate the work you're doing, and love the reddit client <3 