### PR TITLE
claude/fix-comments-pagination-fields-TjlEo

### DIFF
--- a/apps/mobile/src/components/comments/more.tsx
+++ b/apps/mobile/src/components/comments/more.tsx
@@ -64,6 +64,7 @@ export function CommentMoreCard({
           onThread(comment.parentId)
         } else {
           loadMore({
+            depth: comment.depth,
             id: comment.id,
             parentId: comment.parentId,
             postId: post.id,

--- a/apps/mobile/src/components/comments/more.tsx
+++ b/apps/mobile/src/components/comments/more.tsx
@@ -64,8 +64,8 @@ export function CommentMoreCard({
           onThread(comment.parentId)
         } else {
           loadMore({
-            children: comment.children,
             id: comment.id,
+            parentId: comment.parentId,
             postId: post.id,
             sort,
           })

--- a/apps/mobile/src/hooks/mutations/comments/more.ts
+++ b/apps/mobile/src/hooks/mutations/comments/more.ts
@@ -22,6 +22,7 @@ type Data = {
 }
 
 type Variables = {
+  depth: number
   id: string
   parentId: string
   postId: string
@@ -122,6 +123,8 @@ export function useLoadMoreComments() {
       url.searchParams.set('sort', variables.sort)
       url.searchParams.set('sr_detail', 'true')
       url.searchParams.set('comment', variables.parentId)
+      url.searchParams.set('depth', '100')
+      url.searchParams.set('limit', '500')
 
       const response = await reddit({
         url,
@@ -147,32 +150,70 @@ export function useLoadMoreComments() {
           (item) => item.type === 'more' && item.data.id === variables.id,
         )
 
-        if (index >= 0) {
-          const existingIds = new Set(
-            draft.comments.map((item) => item.data.id),
+        if (index < 0) {
+          return
+        }
+
+        const existingIds = new Set(
+          draft.comments.map((item) => item.data.id),
+        )
+
+        // Calculate depth offset for nested more nodes
+        // The comment parameter makes Reddit return the focused comment
+        // at depth 0 (relative), but we need absolute depths
+        let depthOffset = 0
+
+        if (variables.parentId !== variables.postId) {
+          const existingParent = draft.comments.find(
+            (item) =>
+              item.type === 'reply' && item.data.id === variables.parentId,
           )
 
-          const comments = data.comments
-            .map((item) => transformComment(item))
-            .filter((item) => !existingIds.has(item.data.id))
+          const actualParentDepth =
+            existingParent?.type === 'reply'
+              ? existingParent.data.depth
+              : Math.max(0, variables.depth - 1)
 
-          const more = draft.comments[index]
+          const responseParent = data.comments.find(
+            (item) => item.kind === 't1' && item.data.id === variables.parentId,
+          )
 
-          if (more?.type === 'more') {
-            const loadedIds = new Set(comments.map((item) => item.data.id))
+          const responseParentDepth =
+            responseParent?.kind === 't1'
+              ? (responseParent.data.depth ?? 0)
+              : 0
 
-            more.data.children = more.data.children.filter(
-              (id) => !loadedIds.has(id),
-            )
+          depthOffset = actualParentDepth - responseParentDepth
+        }
 
-            if (more.data.children.length > 0) {
-              draft.comments.splice(index, 0, ...comments)
-            } else {
-              draft.comments.splice(index, 1, ...comments)
+        const comments = data.comments
+          .map((item) => {
+            const comment = transformComment(item)
+
+            if (depthOffset !== 0) {
+              comment.data.depth += depthOffset
             }
+
+            return comment
+          })
+          .filter((item) => !existingIds.has(item.data.id))
+
+        const more = draft.comments[index]
+
+        if (more?.type === 'more') {
+          const loadedIds = new Set(comments.map((item) => item.data.id))
+
+          more.data.children = more.data.children.filter(
+            (id) => !loadedIds.has(id),
+          )
+
+          if (more.data.children.length > 0) {
+            draft.comments.splice(index, 0, ...comments)
           } else {
             draft.comments.splice(index, 1, ...comments)
           }
+        } else {
+          draft.comments.splice(index, 1, ...comments)
         }
 
         if (data.after !== undefined) {

--- a/apps/mobile/src/hooks/mutations/comments/more.ts
+++ b/apps/mobile/src/hooks/mutations/comments/more.ts
@@ -2,12 +2,16 @@ import { useMutation } from '@tanstack/react-query'
 
 import { updatePost } from '~/hooks/queries/posts/post'
 import { REDDIT_URI, reddit } from '~/reddit/api'
-import { PostSchema } from '~/schemas/post'
+import {
+  CommentDataSchema,
+  CommentMoreSchema,
+  type CommentsSchema,
+} from '~/schemas/comments'
 import { transformComment } from '~/transformers/comment'
 import { type CommentSort } from '~/types/sort'
 
 type Data = {
-  comments: PostSchema[1]['data']['children']
+  comments: CommentsSchema['data']['children']
 }
 
 type Variables = {
@@ -17,13 +21,54 @@ type Variables = {
   sort: CommentSort
 }
 
+function flattenComments(
+  children: Array<Record<string, unknown>>,
+): CommentsSchema['data']['children'] {
+  const result: CommentsSchema['data']['children'] = []
+
+  for (const item of children) {
+    if (item.kind === 't1') {
+      const data = item.data as Record<string, unknown>
+      const { replies, ...rest } = data
+
+      result.push({
+        data: CommentDataSchema.parse(rest),
+        kind: 't1',
+      })
+
+      if (
+        replies &&
+        typeof replies === 'object' &&
+        (replies as Record<string, unknown>).data
+      ) {
+        const listing = (replies as Record<string, unknown>)
+          .data as Record<string, unknown>
+
+        if (Array.isArray(listing.children)) {
+          result.push(
+            ...flattenComments(
+              listing.children as Array<Record<string, unknown>>,
+            ),
+          )
+        }
+      }
+    } else if (item.kind === 'more') {
+      result.push({
+        data: CommentMoreSchema.parse(item.data),
+        kind: 'more',
+      })
+    }
+  }
+
+  return result
+}
+
 export function useLoadMoreComments() {
   const { isPending, mutate } = useMutation<Data, Error, Variables>({
     async mutationFn(variables) {
       const url = new URL(`/comments/${variables.postId}`, REDDIT_URI)
 
       url.searchParams.set('sort', variables.sort)
-      url.searchParams.set('threaded', 'false')
       url.searchParams.set('sr_detail', 'true')
 
       if (variables.parentId !== variables.postId) {
@@ -34,10 +79,18 @@ export function useLoadMoreComments() {
         url,
       })
 
-      const parsed = PostSchema.parse(response)
+      const listing = (response as Array<Record<string, unknown>>)[1] as
+        | Record<string, unknown>
+        | undefined
+
+      const data = listing?.data as Record<string, unknown> | undefined
+
+      const children = Array.isArray(data?.children)
+        ? (data.children as Array<Record<string, unknown>>)
+        : []
 
       return {
-        comments: parsed[1].data.children,
+        comments: flattenComments(children),
       }
     },
     onSuccess(data, variables) {

--- a/apps/mobile/src/hooks/mutations/comments/more.ts
+++ b/apps/mobile/src/hooks/mutations/comments/more.ts
@@ -1,16 +1,23 @@
 import { useMutation } from '@tanstack/react-query'
 
-import { updatePost } from '~/hooks/queries/posts/post'
+import {
+  updatePost,
+  type PostQueryData,
+  type PostQueryKey,
+} from '~/hooks/queries/posts/post'
+import { queryClient } from '~/lib/query'
 import { REDDIT_URI, reddit } from '~/reddit/api'
 import {
   CommentDataSchema,
   CommentMoreSchema,
   type CommentsSchema,
 } from '~/schemas/comments'
+import { PostSchema } from '~/schemas/post'
 import { transformComment } from '~/transformers/comment'
 import { type CommentSort } from '~/types/sort'
 
 type Data = {
+  after?: string | null
   comments: CommentsSchema['data']['children']
 }
 
@@ -63,17 +70,58 @@ function flattenComments(
   return result
 }
 
+function getPostQueryData(postId: string): PostQueryData | undefined {
+  const cache = queryClient.getQueryCache()
+
+  const queries = cache.findAll({
+    queryKey: ['post', { id: postId }] satisfies PostQueryKey,
+  })
+
+  for (const query of queries) {
+    const data = query.state.data as PostQueryData | undefined
+
+    if (data) {
+      return data
+    }
+  }
+}
+
 export function useLoadMoreComments() {
   const { isPending, mutate } = useMutation<Data, Error, Variables>({
     async mutationFn(variables) {
+      const isRootLevel = variables.parentId === variables.postId
+
+      if (isRootLevel) {
+        const url = new URL(`/comments/${variables.postId}`, REDDIT_URI)
+
+        url.searchParams.set('sort', variables.sort)
+        url.searchParams.set('threaded', 'false')
+        url.searchParams.set('sr_detail', 'true')
+        url.searchParams.set('limit', '50')
+
+        const postData = getPostQueryData(variables.postId)
+
+        if (postData?.after) {
+          url.searchParams.set('after', postData.after)
+        }
+
+        const response = await reddit({
+          url,
+        })
+
+        const parsed = PostSchema.parse(response)
+
+        return {
+          after: parsed[1].data.after,
+          comments: parsed[1].data.children,
+        }
+      }
+
       const url = new URL(`/comments/${variables.postId}`, REDDIT_URI)
 
       url.searchParams.set('sort', variables.sort)
       url.searchParams.set('sr_detail', 'true')
-
-      if (variables.parentId !== variables.postId) {
-        url.searchParams.set('comment', variables.parentId)
-      }
+      url.searchParams.set('comment', variables.parentId)
 
       const response = await reddit({
         url,
@@ -108,7 +156,27 @@ export function useLoadMoreComments() {
             .map((item) => transformComment(item))
             .filter((item) => !existingIds.has(item.data.id))
 
-          draft.comments.splice(index, 1, ...comments)
+          const more = draft.comments[index]
+
+          if (more?.type === 'more') {
+            const loadedIds = new Set(comments.map((item) => item.data.id))
+
+            more.data.children = more.data.children.filter(
+              (id) => !loadedIds.has(id),
+            )
+
+            if (more.data.children.length > 0) {
+              draft.comments.splice(index, 0, ...comments)
+            } else {
+              draft.comments.splice(index, 1, ...comments)
+            }
+          } else {
+            draft.comments.splice(index, 1, ...comments)
+          }
+        }
+
+        if (data.after !== undefined) {
+          draft.after = data.after
         }
       })
     },

--- a/apps/mobile/src/hooks/mutations/comments/more.ts
+++ b/apps/mobile/src/hooks/mutations/comments/more.ts
@@ -1,19 +1,18 @@
 import { useMutation } from '@tanstack/react-query'
 
 import { updatePost } from '~/hooks/queries/posts/post'
-import { addPrefix } from '~/lib/reddit'
 import { REDDIT_URI, reddit } from '~/reddit/api'
-import { MoreCommentsSchema } from '~/schemas/comments'
+import { PostSchema } from '~/schemas/post'
 import { transformComment } from '~/transformers/comment'
 import { type CommentSort } from '~/types/sort'
 
 type Data = {
-  comments: MoreCommentsSchema
+  comments: PostSchema[1]['data']['children']
 }
 
 type Variables = {
-  children: Array<string>
   id: string
+  parentId: string
   postId: string
   sort: CommentSort
 }
@@ -21,25 +20,24 @@ type Variables = {
 export function useLoadMoreComments() {
   const { isPending, mutate } = useMutation<Data, Error, Variables>({
     async mutationFn(variables) {
-      const url = new URL('/api/morechildren', REDDIT_URI)
+      const url = new URL(`/comments/${variables.postId}`, REDDIT_URI)
 
-      url.searchParams.set('api_type', 'json')
-      url.searchParams.set('link_id', addPrefix(variables.postId, 'link'))
       url.searchParams.set('sort', variables.sort)
-      url.searchParams.set(
-        'children',
-        variables.children.slice(0, 50).join(','),
-      )
-      url.searchParams.set('limit_children', 'true')
+      url.searchParams.set('threaded', 'false')
+      url.searchParams.set('sr_detail', 'true')
+
+      if (variables.parentId !== variables.postId) {
+        url.searchParams.set('comment', variables.parentId)
+      }
 
       const response = await reddit({
         url,
       })
 
-      const comments = MoreCommentsSchema.parse(response)
+      const parsed = PostSchema.parse(response)
 
       return {
-        comments,
+        comments: parsed[1].data.children,
       }
     },
     onSuccess(data, variables) {
@@ -49,21 +47,13 @@ export function useLoadMoreComments() {
         )
 
         if (index >= 0) {
-          const comments = data.comments.json.data.things.map((item) =>
-            transformComment(item),
+          const existingIds = new Set(
+            draft.comments.map((item) => item.data.id),
           )
 
-          const more = draft.comments[index]
-
-          if (more?.type === 'more') {
-            more.data.children = more.data.children.slice(50)
-
-            if (more.data.children.length > 0) {
-              draft.comments.splice(index, 1, ...comments, more)
-
-              return
-            }
-          }
+          const comments = data.comments
+            .map((item) => transformComment(item))
+            .filter((item) => !existingIds.has(item.data.id))
 
           draft.comments.splice(index, 1, ...comments)
         }

--- a/apps/mobile/src/hooks/mutations/comments/more.ts
+++ b/apps/mobile/src/hooks/mutations/comments/more.ts
@@ -39,11 +39,17 @@ function flattenComments(
       const data = item.data as Record<string, unknown>
       const { replies, ...rest } = data
 
-      result.push({
-        data: CommentDataSchema.parse(rest),
-        kind: 't1',
-      })
+      const parsed = CommentDataSchema.safeParse(rest)
 
+      if (parsed.success) {
+        result.push({
+          data: parsed.data,
+          kind: 't1',
+        })
+      }
+
+      // Always recurse into replies even if this comment failed
+      // validation, so we can still reach nested children
       if (
         replies &&
         typeof replies === 'object' &&
@@ -61,10 +67,14 @@ function flattenComments(
         }
       }
     } else if (item.kind === 'more') {
-      result.push({
-        data: CommentMoreSchema.parse(item.data),
-        kind: 'more',
-      })
+      const parsed = CommentMoreSchema.safeParse(item.data)
+
+      if (parsed.success) {
+        result.push({
+          data: parsed.data,
+          kind: 'more',
+        })
+      }
     }
   }
 

--- a/apps/mobile/src/hooks/mutations/comments/more.ts
+++ b/apps/mobile/src/hooks/mutations/comments/more.ts
@@ -1,11 +1,6 @@
 import { useMutation } from '@tanstack/react-query'
 
-import {
-  updatePost,
-  type PostQueryData,
-  type PostQueryKey,
-} from '~/hooks/queries/posts/post'
-import { queryClient } from '~/lib/query'
+import { getPost, updatePost } from '~/hooks/queries/posts/post'
 import { REDDIT_URI, reddit } from '~/reddit/api'
 import {
   CommentDataSchema,
@@ -55,8 +50,10 @@ function flattenComments(
         typeof replies === 'object' &&
         (replies as Record<string, unknown>).data
       ) {
-        const listing = (replies as Record<string, unknown>)
-          .data as Record<string, unknown>
+        const listing = (replies as Record<string, unknown>).data as Record<
+          string,
+          unknown
+        >
 
         if (Array.isArray(listing.children)) {
           result.push(
@@ -81,22 +78,6 @@ function flattenComments(
   return result
 }
 
-function getPostQueryData(postId: string): PostQueryData | undefined {
-  const cache = queryClient.getQueryCache()
-
-  const queries = cache.findAll({
-    queryKey: ['post', { id: postId }] satisfies PostQueryKey,
-  })
-
-  for (const query of queries) {
-    const data = query.state.data as PostQueryData | undefined
-
-    if (data) {
-      return data
-    }
-  }
-}
-
 export function useLoadMoreComments() {
   const { isPending, mutate } = useMutation<Data, Error, Variables>({
     async mutationFn(variables) {
@@ -110,10 +91,10 @@ export function useLoadMoreComments() {
         url.searchParams.set('sr_detail', 'true')
         url.searchParams.set('limit', '50')
 
-        const postData = getPostQueryData(variables.postId)
+        const post = getPost(variables.postId)
 
-        if (postData?.after) {
-          url.searchParams.set('after', postData.after)
+        if (post?.after) {
+          url.searchParams.set('after', post.after)
         }
 
         const response = await reddit({
@@ -164,9 +145,7 @@ export function useLoadMoreComments() {
           return
         }
 
-        const existingIds = new Set(
-          draft.comments.map((item) => item.data.id),
-        )
+        const existingIds = new Set(draft.comments.map((item) => item.data.id))
 
         // Calculate depth offset for nested more nodes
         // The comment parameter makes Reddit return the focused comment
@@ -189,9 +168,7 @@ export function useLoadMoreComments() {
           )
 
           const responseParentDepth =
-            responseParent?.kind === 't1'
-              ? (responseParent.data.depth ?? 0)
-              : 0
+            responseParent?.kind === 't1' ? (responseParent.data.depth ?? 0) : 0
 
           depthOffset = actualParentDepth - responseParentDepth
         }

--- a/apps/mobile/src/hooks/queries/posts/post.ts
+++ b/apps/mobile/src/hooks/queries/posts/post.ts
@@ -32,6 +32,7 @@ export type PostQueryKey = [
 ]
 
 export type PostQueryData = {
+  after?: string | null
   comments: Array<Comment>
   post: Post
 }
@@ -100,6 +101,7 @@ export function usePost({ commentId, id, sort }: Props) {
         .where(eq(db.schema.collapsed.postId, id))
 
       return {
+        after: response[1].data.after,
         comments: comments.map((item) =>
           transformComment(item, {
             collapseAutoModerator,

--- a/apps/mobile/src/hooks/queries/posts/post.ts
+++ b/apps/mobile/src/hooks/queries/posts/post.ts
@@ -179,7 +179,7 @@ export function usePost({ commentId, id, sort }: Props) {
   }
 }
 
-function getPost(id: string): Undefined<PostQueryData> {
+export function getPost(id: string): Undefined<PostQueryData> {
   const cache = queryClient.getQueryCache()
 
   const queries = cache.findAll({

--- a/apps/mobile/src/reddit/api.ts
+++ b/apps/mobile/src/reddit/api.ts
@@ -50,6 +50,10 @@ export async function reddit<Response>({ body, method = 'get', url }: Props) {
 
   uri.searchParams.set('raw_json', '1')
 
+  if (__DEV__) {
+    console.log('uri', uri.toString())
+  }
+
   const response = await fetch(uri, request)
 
   if (url === '/api/read_all_messages') {


### PR DESCRIPTION
The non-OAuth /api/morechildren endpoint returns HTML content with minimal
fields (parent, contentHTML, contentText, link, id) instead of full structured
JSON comment data. Switch to the /comments/{postId} endpoint with the comment
parameter to fetch full comment data with all fields, deduplicating against
existing comments in the cache.

https://claude.ai/code/session_019Dmx5ye1TtFRKQ2VEQX3gT