### PR TITLE
Fix crash when persisted feedType is stale after removing 'all' option

### DIFF
--- a/apps/mobile/src/app/(drawer)/(tabs)/(home,search,profile,notifications,settings)/index.tsx
+++ b/apps/mobile/src/app/(drawer)/(tabs)/(home,search,profile,notifications,settings)/index.tsx
@@ -23,7 +23,12 @@ import { FeedType } from '~/types/sort'
 
 const schema = z.object({
   feed: z.string().optional(),
-  type: z.enum(FeedType).catch(defaultsStore.getState().feedType),
+  type: z.enum(FeedType).catch(() => {
+    const stored = defaultsStore.getState().feedType
+    return FeedType.includes(stored as (typeof FeedType)[number])
+      ? stored
+      : 'home'
+  }),
 })
 
 export type HomeParams = z.infer<typeof schema>


### PR DESCRIPTION
## Summary

- Fixes a crash on the home screen when a user has `'all'` persisted as their `feedType` in MMKV from before it was removed as a valid `FeedType`
- `z.enum(FeedType).catch()` was using the raw store value as fallback without validating it, causing `FeedTypeColors['all']` to be `undefined` and `.accent` to throw a `TypeError`
- The fix validates the stored value against the current `FeedType` enum before using it, falling back to `'home'` if invalid